### PR TITLE
#1 can't open Galaxies from launcher

### DIFF
--- a/sgtlauncher/SgtSocketLauncher.py
+++ b/sgtlauncher/SgtSocketLauncher.py
@@ -175,5 +175,5 @@ def is_withdrawn(window_id: int) -> bool:
                                         0, 2 ** 32 - 1).reply()
     property_value = get_property_value(property_reply)
     c.disconnect()
-    withdrawn = not property_reply or property_value[0] == 0
+    withdrawn = not property_value or property_value[0] == 0
     return withdrawn


### PR DESCRIPTION
I didn't manage to reproduce this bug on Xubuntu, but I have reproduced it on Lubuntu.
Wrong variable was checked in a condition.
> When the window is withdrawn, the window manager will either change the state field's value to WithdrawnState or it will remove the WM_STATE property entirely.